### PR TITLE
Remove ktor Bintray URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ repositories {
     jcenter()
     mavenCentral()
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
-    maven { url "https://dl.bintray.com/kotlin/ktor" }
 }
 
 kotlin {


### PR DESCRIPTION
Ktor is no longer published to the bintray repo but to central directly. Remove it to avoid confusion